### PR TITLE
댓글 수정/삭제 시 낙관적 업데이트 및 setTimeout 구현

### DIFF
--- a/components/modals/delete-modal.tsx
+++ b/components/modals/delete-modal.tsx
@@ -24,7 +24,7 @@ export default function DeleteModal({ id, type }: Props) {
 
   const deleteMutation = useMutation({
     mutationFn: async () => {
-      type === 'comment' ? deleteComment(session, id) : deleteEpiday(session, id);
+      return type === 'comment' ? deleteComment(session, id) : deleteEpiday(session, id);
     },
     onSuccess: () => {
       if (type === 'comment') {


### PR DESCRIPTION
## 문제

1. 댓글 삭제 시 바로 반영 안 됨
2. 댓글 수정 및 삭제 시 찰나에 이전 상태이다가 변경사항 반영됨

## 해결

1. 댓글 삭제 시 바로 반영
2. onMutate로 낙관적 업데이트 구현하였지만 여전히 찰나에 이전 내용이 보이다가 반영이 되어서 setTimeout으로 추가 구현
 ** 네트워크가 매우 느렸을 시 setTimeout 시간 이후에 반영이 될 수 있음


<br />

https://github.com/user-attachments/assets/7b1841ce-21e6-49ec-8a52-31bfe073dd5a




 